### PR TITLE
Fixing the issue with outside click binding

### DIFF
--- a/src/lwc/comboboxAutocomplete/comboboxAutocomplete.js
+++ b/src/lwc/comboboxAutocomplete/comboboxAutocomplete.js
@@ -13,20 +13,21 @@ export default class ComboboxAutocomplete extends LightningElement {
 
     filteredOptions = [];
     domElement;
+    
+    _handleOutsideClick;
 
     constructor() {
         super();
-        //this.handleOutsideClick = 
-        this.handleOutsideClick.bind(this);
+        this._handleOutsideClick = this.handleOutsideClick.bind(this);
     }
 
     connectedCallback() {
         this.filteredOptions = [...this.options];
-        document.addEventListener('click', this.handleOutsideClick);
+        document.addEventListener('click', this._handleOutsideClick);
     }
 
     disconnectedCallback() {
-        document.removeEventListener('click', this.handleOutsideClick);
+        document.removeEventListener('click', this._handleOutsideClick);
     }
 
     filterOptions(event) {


### PR DESCRIPTION
Class is an immutable property due to which it cannot be reassigned hence creating a temporary variable and binding the instance to the temp variable created. tested it on one of my sandboxes it works.